### PR TITLE
Enable advanced view on mobile

### DIFF
--- a/src/components/carbon/Header.js
+++ b/src/components/carbon/Header.js
@@ -75,10 +75,6 @@ const RightControls = styled.div`
   justify-content: flex-end;
   flex: 1 1;
   padding-right: 0.8rem;
-
-  @media (max-width: 768px) {
-    display: none;
-  }
 `;
 
 const WebsiteHeader = () => {


### PR DESCRIPTION
https://github.com/ocius/website/issues/167
I mentioned in the issue, button was intentionally disabled to stop mobile users from vising the advanced view page, i'll pass it onto Robert.

heres how it should look
![image](https://user-images.githubusercontent.com/18486383/86712867-d3248200-c060-11ea-807a-f1b87230a11a.png)
http://kevin.d3fhwa1e0f950h.amplifyapp.com/live