### PR TITLE
Fix missing camera thumbnails

### DIFF
--- a/src/components/CameraImageSlider/index.js
+++ b/src/components/CameraImageSlider/index.js
@@ -5,6 +5,9 @@ import Slider from 'react-slick';
 import styled from 'styled-components';
 import { uid } from 'react-uid';
 
+// Import medium zoom styles
+import '../../css/imagezoom.css';
+
 import PaginatorButton from './PaginatorButton';
 
 const Carousel = styled.div`
@@ -85,15 +88,14 @@ const CameraSlider = ({ images, title, settings, customSettings }) => {
         >
           {images.map((image, index) => {
             return (
-              <ImageZoom
-                key={uid(image, index)}
-                image={{
-                  src: image,
-                  alt: 'Live camera view',
-                  className: 'webcam-img',
-                  style: { width: '100%' },
-                }}
-              />
+              <ImageZoom key={uid(image, index)}>
+                <img
+                  src={image}
+                  alt="Live camera view"
+                  className="webcam-img"
+                  style={{ width: '100%' }}
+                />
+              </ImageZoom>
             );
           })}
         </Slider>

--- a/src/css/imagezoom.css
+++ b/src/css/imagezoom.css
@@ -1,0 +1,54 @@
+[data-rmiz-wrap='visible'],
+[data-rmiz-wrap='hidden'] {
+  position: relative;
+}
+
+[data-rmiz-wrap='hidden'] {
+  visibility: hidden;
+}
+
+[data-rmiz-overlay] {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  transition-property: background-color;
+}
+
+[data-rmiz-btn-open],
+[data-rmiz-btn-close] {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+
+  /* reset styles */
+  margin: 0;
+  padding: 0;
+  border: none;
+  border-radius: 0;
+  font: inherit;
+  color: inherit;
+  background: none;
+  appearance: none;
+}
+
+[data-rmiz-btn-open] {
+  cursor: zoom-in;
+}
+
+[data-rmiz-btn-close] {
+  cursor: zoom-out;
+}
+
+[data-rmiz-modal-content] {
+  position: absolute;
+  transition-property: transform;
+  transform-origin: center center;
+}


### PR DESCRIPTION
The ```react-medium-image-zoom``` library has updated its syntax in v4 and camera images are gone. This PR fixes this behaviour. Here's the [blog post](https://robertwpearce.com/announcing-react-medium-image-zoom-v4.html) about it.