### PR TITLE
Fix broken CodeBuild config - `buildspec.yml`

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,15 +1,15 @@
-version: 0.1
+version: 0.2
 phases:
   install:
     commands:
       - curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
       - export NVM_DIR="$HOME/.nvm"
-      - . "$NVM_DIR/nvm.sh"
-      - nvm install lts/*
-      - nvm use lts/*
-      - node -v
+      - '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"'
+      - '[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"'
   pre_build:
     commands:
+      - . "$NVM_DIR/nvm.sh" && nvm install lts/*
+      - node -v
       - npm ci
   build:
     commands:

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -2,14 +2,22 @@ version: 0.1
 phases:
   install:
     commands:
-      - "apt update"
-      - "npm install"
-      - "npm install -g gatsby"
-      - "gatsby build"
+      - curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
+  pre_build:
+    commands:
+      - nvm install lts/*
+      - nvm use lts/*
+      - npm ci
   build:
     commands:
-      - 'aws s3 sync "public/" "s3://ocius-static-website" --delete'
-      - 'aws cloudfront create-invalidation --distribution-id E3DSYTEJZITXF6 --paths "/*"'
+      - nvm install lts/*
+      - nvm use lts/*
+      - node -v
+      - npm run build
+  post_build:
+    commands:
+      - aws s3 sync "public/" "s3://ocius-static-website" --delete
+      - aws cloudfront create-invalidation --distribution-id E3DSYTEJZITXF6 --paths "/*"
 artifacts:
   base-directory: public
   files:

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -3,7 +3,8 @@ phases:
   install:
     commands:
       - curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
-      - . ~/.nvm/nvm.sh
+      - export NVM_DIR="$HOME/.nvm"
+      - [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" # This loads nvm
       - nvm install lts/*
       - nvm use lts/*
       - node -v

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -4,7 +4,7 @@ phases:
     commands:
       - curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
       - export NVM_DIR="$HOME/.nvm"
-      - '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" # This loads nvm'
+      - . "$NVM_DIR/nvm.sh"
       - nvm install lts/*
       - nvm use lts/*
       - node -v

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -3,16 +3,15 @@ phases:
   install:
     commands:
       - curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
-  pre_build:
-    commands:
-      - nvm install lts/*
-      - nvm use lts/*
-      - npm ci
-  build:
-    commands:
+      - . ~/.nvm/nvm.sh
       - nvm install lts/*
       - nvm use lts/*
       - node -v
+  pre_build:
+    commands:
+      - npm ci
+  build:
+    commands:
       - npm run build
   post_build:
     commands:

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -4,7 +4,7 @@ phases:
     commands:
       - curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
       - export NVM_DIR="$HOME/.nvm"
-      - [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" # This loads nvm
+      - '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" # This loads nvm'
       - nvm install lts/*
       - nvm use lts/*
       - node -v


### PR DESCRIPTION
This build is broken because the newer versions of Gatsby require new version of node. Default node version that comes with Ubuntu is outdated.