### PR TITLE
Fix missing logotype of eco boats partner

### DIFF
--- a/src/pages/about/index.js
+++ b/src/pages/about/index.js
@@ -1466,7 +1466,7 @@ export const query = graphql`
     TAS: file(relativePath: { eq: "pages/about/images/TAS-logo.png" }) {
       ...imageSharpLogotype
     }
-    EcoBoats: file(relativePath: { eq: "pages/about/images/EcoBoats-logo.jpg" }) {
+    EcoBoats: file(relativePath: { eq: "pages/about/images/EcoBoat-logo.jpg" }) {
       ...imageSharpLogotype
     }
   }


### PR DESCRIPTION
A quick fix (incorrect path to the logotype).